### PR TITLE
allow choosing whether to install redis in the same host as enketo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 enketo_user: "enketo"
 enketo_home: "/home/{{ enketo_user }}"
 enketo_group: "www-data"
+enketo_install_redis: true
 enketo_redis_user: "redis"
 enketo_redis_bind_address: "127.0.0.1"
 enketo_redis_cache_dir: "/var/lib/redis/redis-cache"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ dependencies:
    become: true
    become_user: "root"
    redis_bind: "{{ enketo_redis_bind_address }}"
+   when: enketo_install_redis 
    tags:
     - redis
 


### PR DESCRIPTION
Adds checks that , defaulting to install.
setting `enketo_install_redis = false` skips installing redis, which then means one can set a remote redis host instead.
