### PR TITLE
Remove Become When Including NVM Role

### DIFF
--- a/tasks/install-nvm.yml
+++ b/tasks/install-nvm.yml
@@ -2,8 +2,6 @@
 - name: Install Node Version Manager
   include_role:
     name: onaio.nvm
-  become: true
-  become_user: "{{ enketo_user }}"
   vars:
     nvm_user: "{{ enketo_user }}"
     nvm_group: "{{ enketo_group }}"


### PR DESCRIPTION
Remove `become` and `become_user` as they are not supported on `include_role` module and NVM role uses the `nvm_user` as the become user when running the tasks anyway.