### PR TITLE
Disable nodejs rejection self signed certs

### DIFF
--- a/tasks/install-enketo.yml
+++ b/tasks/install-enketo.yml
@@ -143,6 +143,13 @@
   notify:
     - "reload pm2-{{ enketo_user }}"
 
+- name: Disable rejection of self signed certs
+  lineinfile:
+    path: "/etc/systemd/system/pm2-{{ enketo_user }}.service"
+    line: "export NODE_TLS_REJECT_UNAUTHORIZED=0"
+    state: present
+  when: enketo_node_tls_reject is defined
+
 - name: reload systemd daemons
   become: true
   become_user: "root"

--- a/tasks/install-enketo.yml
+++ b/tasks/install-enketo.yml
@@ -144,11 +144,13 @@
     - "reload pm2-{{ enketo_user }}"
 
 - name: Disable rejection of self signed certs
+  become: true
+  become_user: "root"
   lineinfile:
     path: "/etc/systemd/system/pm2-{{ enketo_user }}.service"
     line: "export NODE_TLS_REJECT_UNAUTHORIZED=0"
     state: present
-  when: enketo_node_tls_reject is defined
+  when: enketo_set_node_tls_reject_env is defined and enketo_set_node_tls_reject_env
 
 - name: reload systemd daemons
   become: true


### PR DESCRIPTION
- Add task to optionally disable nodejs from rejecting self signed certificates