### PR TITLE
Set "false" as the default value for enketo_enable_submission_logging

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,5 +90,5 @@ enketo_bower_version: "1.8.4"
 enketo_mocha_version: "5.2.0"
 enketo_pm2_version: "2.10.4"
 enketo_init_system: "upstart"
-enketo_enable_submission_logging: false
+enketo_enable_submission_logging: "false"
 


### PR DESCRIPTION
# Changes

- Change `enketo_enable_submission_logging` default value to `"false"` instead of `false`; If `false` is used as the value, `False` is kept as the value in the template.