### PR TITLE
Ensure enketo_enable_submission_logging value is always lowercase

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,6 +7,7 @@
         name: "ansible-enketo"
       vars:
         - test: true
+        - enketo_enable_submission_logging: True
         - enketo_install_redis: false
         - enketo_offline_color_hexcode: "#0b77c2"
         - enketo_primary_color_hexcode: "#0b77c2"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -20,3 +20,12 @@
     - name: Check that host file belongs to correct user
       fail:
       when: not config_file.stat.pw_name == "enketo"
+
+    - name: Ensure submissions configuration is set to lowercase
+      lineinfile:
+        name: "/home/enketo/app/config/config.json"
+        line: '        "submissions": true'
+        state: present
+      check_mode: yes
+      register: conf
+      failed_when: (conf is changed) or (conf is failed)

--- a/templates/enketo/config.json.j2
+++ b/templates/enketo/config.json.j2
@@ -25,7 +25,7 @@
     "themes supported":[{% for theme in enketo_supported_themes %}"{{ theme }}"{% if loop.index != loop.length %}, {% endif %}{% endfor %}],
     "base path": "",
     "log": {
-        "submissions": {{ enketo_enable_submission_logging }}
+        "submissions": {{ enketo_enable_submission_logging | lower }}
     },
     "support": {
         "email": "{{ enketo_support_email }}"


### PR DESCRIPTION
Fixes: https://github.com/onaio/ansible-enketo/issues/39
- tested locally with molecule and verified that the default `enketo_enable_submission_logging` is lowercase
```
    "log": {
        "submissions": false
    },
```